### PR TITLE
Plumb the system config thru to home.nix, make hid-nintendo use boot.kernelPackages

### DIFF
--- a/configuration.nix
+++ b/configuration.nix
@@ -77,20 +77,23 @@
   };
 
   nixpkgs = {
-    config.allowUnfreePredicate = pkg:
-      builtins.elem (lib.getName pkg) [
-        "discord"
-        "google-chrome"
-        "steam"
-        "steam-original"
-        "steam-run"
-        "sublimetext4"
-        "zoom"
-        "nvidia-x11"
-        "nvidia-settings"
-        "fcitx5"
-        "minecraft-launcher"
-      ];
+    config = {
+      allowUnfreePredicate = pkg:
+        builtins.elem (lib.getName pkg) [
+          "discord"
+          "google-chrome"
+          "steam"
+          "steam-original"
+          "steam-run"
+          "sublimetext4"
+          "zoom"
+          "nvidia-x11"
+          "nvidia-settings"
+          "fcitx5"
+          "minecraft-launcher"
+        ];
+      permittedInsecurePackages = [ "openssl-1.1.1w" ];
+    };
     hostPlatform = lib.mkDefault "x86_64-linux";
   };
 


### PR DESCRIPTION
The `systemConfig` in `home.nix` now refers to the `config` in `configuration.nix`, so the options in https://search.nixos.org/options? will exist for it.